### PR TITLE
Fix MultiLabelBinarizer of gtr disciplines

### DIFF
--- a/notebooks/01_cooccurence_networks_gtr.ipynb
+++ b/notebooks/01_cooccurence_networks_gtr.ipynb
@@ -848,7 +848,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mlb = MultiLabelBinarizer(classes=discipline_cooccurrence_df.columns)\n",
+    "mlb = MultiLabelBinarizer(classes=discipline_cooccurrence_df.index)\n",
     "discipline_binarized = mlb.fit_transform(gtr_projects_df['discipline_set'])\n",
     "discipline_binarized_df = pd.DataFrame(discipline_binarized, columns=mlb.classes_)\n",
     "\n",


### PR DESCRIPTION
Changed MultiLabelBinarizer classes from using columns of discipline_cooccurrence_df to index to avoid omission of first community.